### PR TITLE
feat: 이메일 인증 관련 API 추가

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import * as styles from './styles'
 export type TextSize = 'xs' | 'sm' | 'base'
-export type ButtonStyle = 'default' | 'primary' | 'secondary'
+export type ButtonStyle = 'default' | 'primary' | 'secondary' | 'modal'
 export type TextAlign = 'left' | 'right' | 'center'
 type Props = {
   children?: React.ReactNode

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -34,6 +34,10 @@ export const Style = {
     color: theme.gray[300],
     bgColor: 'transparent',
   },
+  modal: {
+    color: 'white',
+    bgColor: 'transparent',
+  },
 }
 export const button = css`
   width: 100%;

--- a/src/components/ModalAlert/index.tsx
+++ b/src/components/ModalAlert/index.tsx
@@ -10,13 +10,16 @@ export type ModalType = 'alert' | 'confirm'
 type Props = {
   title?: string
   isOpen: boolean
-  type: ModalType
+  type?: ModalType
   btnName?: string
   btnProp?: boolean
   onClick: () => void
 }
 
 const customStyles: Modal.Styles = {
+  overlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+  },
   content: {
     display: 'flex',
     flexDirection: 'column',
@@ -45,16 +48,16 @@ const ModalAlert = ({
   onClick,
 }: Props) => {
   return (
-    <Modal style={customStyles} isOpen={isOpen} ariaHideApp={false}>
+    <Modal
+      style={customStyles}
+      isOpen={isOpen}
+      ariaHideApp={false}
+      onRequestClose={onClick} // close modal when overlay clicked
+    >
       <div css={styles.titleBlock}>{title}</div>
       <div css={styles.btnBlock}>
         {type == 'alert' ? (
-          <Button
-            align="center"
-            size="base"
-            style="secondary"
-            onClick={onClick}
-          >
+          <Button align="center" size="base" style="modal" onClick={onClick}>
             확인
           </Button>
         ) : (

--- a/src/css/global.tsx
+++ b/src/css/global.tsx
@@ -31,6 +31,13 @@ export const globalCss = (theme: Theme) => css`
   button {
     cursor: pointer;
   }
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    transition: background-color 5000s;
+    -webkit-text-fill-color: #fff !important;
+  }
 `
 
 export const componentContainer = css`

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -1,0 +1,1 @@
+export const apiBaseUrl = 'http://www.alcoholic.tk:80'

--- a/src/pages/api/email/check/[type].ts
+++ b/src/pages/api/email/check/[type].ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { apiBaseUrl } from '@/libs/config'
+import { URLSearchParams } from 'url'
+async function EmailCheck(req: NextApiRequest, res: NextApiResponse) {
+  const { type, email } = req.query
+  const searchParams = new URLSearchParams({ email: `${email}` }).toString()
+  const response = await fetch(
+    `${apiBaseUrl}/api/mail/check/${type}?` + searchParams,
+  )
+  const data = await response.json()
+  res.status(response.status).json(data)
+}
+
+export default EmailCheck

--- a/src/pages/api/email/send/[type].ts
+++ b/src/pages/api/email/send/[type].ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { apiBaseUrl } from '@/libs/config'
+import { URLSearchParams } from 'url'
+async function EmailSend(req: NextApiRequest, res: NextApiResponse) {
+  const { type, email } = req.query
+  const searchParams = new URLSearchParams({ email: `${email}` }).toString()
+  const response = await fetch(
+    `${apiBaseUrl}/api/mail/send/${type}?` + searchParams,
+  )
+  const data = await response.json()
+  res.status(response.status).json(data)
+}
+
+export default EmailSend

--- a/src/pages/login/find-id/index.tsx
+++ b/src/pages/login/find-id/index.tsx
@@ -9,9 +9,11 @@ import TextField from '@/components/TextField'
 import Button from '@/components/Button'
 import ValidateMessage from '@/components/ValidateMessage'
 import AuthTimer from '@/components/AuthTimer'
+import ModalAlert from '@/components/ModalAlert'
 
 import * as styles from '@/css/login/findIdStyles'
 
+const MAIL_TYPE = 'id'
 type FormTypes = {
   email: string
 }
@@ -19,6 +21,7 @@ const FindId = () => {
   const {
     register,
     setValue,
+    getValues,
     handleSubmit,
     formState: { isValid, errors }, // isValid: Set to true if the form doesn't have any errors.
   } = useForm<FormTypes>({
@@ -26,27 +29,45 @@ const FindId = () => {
   })
   const [checkDisabled, setCheckDisabled] = useState<boolean>(true)
   const [time, setTime] = useState<number>(5)
+  const [modalVisible, setModalVisible] = useState<boolean>(false)
+  const [modalTitle, setModalTitle] = useState<string>('')
 
   const handleChange = ({ name, value }: any) => {
     // TODO: any 타입 변경
     setValue(name, value, { shouldValidate: true })
   }
-  const handleClick = (data: FormTypes) => {
-    // TODO: 인증 요청 API
-    console.log('인증 요청 클릭', data)
+  const handleClick = async (formData: FormTypes) => {
+    const { email } = formData
 
-    // 인증 확인 disabled -> default
-    setCheckDisabled(false)
+    // const response = await fetch(`/api/email/send/${MAIL_TYPE}?email=${email}`)
+    // const data = await response.json()
+    const data = { success: true, message: '123' }
+    if (data) {
+      setModalVisible(true)
+      setModalTitle(data.message)
 
-    if (!checkDisabled) {
-      // TODO: 재요청
-      setTime(5)
+      if (data.success) {
+        setCheckDisabled(false) // 인증 확인 disabled -> default
+        // 재요청
+        if (!checkDisabled) {
+          setTime(5)
+        }
+      }
     }
   }
 
-  const handleCheckClick = () => {
-    // TODO: 인증 확인 API -> 아이디 찾기 결과
-    Router.push('/login/find-id/success')
+  const handleCheckClick = async () => {
+    const email = getValues('email')
+    const response = await fetch(`/api/email/check/${MAIL_TYPE}?email=${email}`)
+    const data = await response.json()
+    if (data) {
+      setModalVisible(true)
+      setModalTitle(data.message)
+
+      if (data.success) {
+        Router.push('/login/find-id/success')
+      }
+    }
   }
 
   return (
@@ -103,6 +124,12 @@ const FindId = () => {
           인증 확인
         </Button>
       </div>
+
+      <ModalAlert
+        isOpen={modalVisible}
+        title={modalTitle}
+        onClick={() => setModalVisible(!modalVisible)}
+      />
     </>
   )
 }

--- a/src/pages/login/find-id/index.tsx
+++ b/src/pages/login/find-id/index.tsx
@@ -39,9 +39,8 @@ const FindId = () => {
   const handleClick = async (formData: FormTypes) => {
     const { email } = formData
 
-    // const response = await fetch(`/api/email/send/${MAIL_TYPE}?email=${email}`)
-    // const data = await response.json()
-    const data = { success: true, message: '123' }
+    const response = await fetch(`/api/email/send/${MAIL_TYPE}?email=${email}`)
+    const data = await response.json()
     if (data) {
       setModalVisible(true)
       setModalTitle(data.message)


### PR DESCRIPTION
## 작업내용
- `Button`에 `modal` style을 추가했습니다.
- `ModalAlert`에 적용된 Button style을 modal로 변경했습니다.
- `ModalAlert`에 기본 overlay가 적용되어있어 투명하게 변경했습니다.
- `ModalAlert` overlay 클릭 시, 모달 창이 닫히도록 수정했습니다.
- input에 자동으로 텍스트가 들어갔을 때 발생하는 css를 수정했습니다.
- 인증 이메일 전송, 이메일 인증기록 조회 API를 추가했습니다.
- 아이디 찾기에 이메일 관련 API를 적용했습니다.

## 전달사항
- 만약 해당 PR을 먼저 merge하게 된다면 #31 에서 develop pull 받고 추가 수정해주세요.
- 혹시 conflict 나면 말씀해주세요.